### PR TITLE
Control order between logically related events

### DIFF
--- a/server/tests/test_api/test_rest.py
+++ b/server/tests/test_api/test_rest.py
@@ -310,82 +310,175 @@ def test_get_tags_by_wikidata_ids_missing_tags(
     assert response.json() == {"wikidata_ids": expected_response}
 
 
-def test_create_event(client: TestClient, auth_headers: dict):
-    person_input = WikiDataPersonInput(
-        wikidata_id="Q1339",
-        wikidata_url="https://www.wikidata.org/wiki/Q1339",
-        name="Johann Sebastian Bach",
-    )
+class TestCreateEvent:
+    def _event(self, client: TestClient, auth_headers: dict) -> WikiDataEventInput:
+        person_input = WikiDataPersonInput(
+            wikidata_id="Q1339",
+            wikidata_url="https://www.wikidata.org/wiki/Q1339",
+            name="Johann Sebastian Bach",
+        )
 
-    created_person_output = client.post(
-        "/wikidata/people", data=person_input.model_dump_json(), headers=auth_headers
-    )
-    created_person = WikiDataPersonOutput.model_validate(created_person_output.json())
+        created_person_output = client.post(
+            "/wikidata/people",
+            data=person_input.model_dump_json(),
+            headers=auth_headers,
+        )
+        created_person = WikiDataPersonOutput.model_validate(
+            created_person_output.json()
+        )
 
-    place_input = WikiDataPlaceInput(
-        wikidata_id="Q7070",
-        wikidata_url="https://www.wikidata.org/wiki/Q7070",
-        name="Eisenach",
-        latitude=50.974722,
-        longitude=10.324444,
-    )
+        place_input = WikiDataPlaceInput(
+            wikidata_id="Q7070",
+            wikidata_url="https://www.wikidata.org/wiki/Q7070",
+            name="Eisenach",
+            latitude=50.974722,
+            longitude=10.324444,
+        )
 
-    created_place_output = client.post(
-        "/wikidata/places", data=place_input.model_dump_json(), headers=auth_headers
-    )
-    created_place = WikiDataPlaceOutput.model_validate(created_place_output.json())
+        created_place_output = client.post(
+            "/wikidata/places", data=place_input.model_dump_json(), headers=auth_headers
+        )
+        created_place = WikiDataPlaceOutput.model_validate(created_place_output.json())
 
-    time_input = WikiDataTimeInput(
-        wikidata_id="Q69125241",
-        wikidata_url="https://www.wikidata.org/wiki/Q69125241",
-        name="March 31st, 1685",
-        date="+1685-03-21T00:00:00Z",
-        calendar_model="https://www.wikidata.org/wiki/Q12138",
-        precision=11,
-    )
+        time_input = WikiDataTimeInput(
+            wikidata_id="Q69125241",
+            wikidata_url="https://www.wikidata.org/wiki/Q69125241",
+            name="March 31st, 1685",
+            date="+1685-03-21T00:00:00Z",
+            calendar_model="https://www.wikidata.org/wiki/Q12138",
+            precision=11,
+        )
 
-    created_time_output = client.post(
-        "/wikidata/times", data=time_input.model_dump_json(), headers=auth_headers
-    )
-    created_time = WikiDataTimeOutput.model_validate(created_time_output.json())
+        created_time_output = client.post(
+            "/wikidata/times", data=time_input.model_dump_json(), headers=auth_headers
+        )
+        created_time = WikiDataTimeOutput.model_validate(created_time_output.json())
 
-    summary_text = "Johann Sebastian Bach was born on March 31st, 1685 in Eisenach."
-    event_input = WikiDataEventInput(
-        summary=summary_text,
-        citation=WikiDataCitationInput(
-            access_date=datetime.now(timezone.utc),
-            wikidata_item_id="Q1339",
-            wikidata_item_title="Johann Sebastian Bach",
-            wikidata_item_url="https://www.wikidata.org/wiki/Q1339",
-        ),
-        tags=[
-            TagInput(
-                id=created_person.id,
-                name=created_person.name,
-                start_char=summary_text.find(created_person.name),
-                stop_char=summary_text.find(created_person.name)
-                + len(created_person.name),
+        summary_text = "Johann Sebastian Bach was born on March 31st, 1685 in Eisenach."
+        event_input = WikiDataEventInput(
+            summary=summary_text,
+            citation=WikiDataCitationInput(
+                access_date=datetime.now(timezone.utc),
+                wikidata_item_id="Q1339",
+                wikidata_item_title="Johann Sebastian Bach",
+                wikidata_item_url="https://www.wikidata.org/wiki/Q1339",
             ),
-            TagInput(
-                id=created_place.id,
-                name=created_place.name,
-                start_char=summary_text.find(created_place.name),
-                stop_char=summary_text.find(created_place.name)
-                + len(created_place.name),
-            ),
-            TagInput(
-                id=created_time.id,
-                name=created_time.name,
-                start_char=summary_text.find(created_time.name),
-                stop_char=summary_text.find(created_time.name) + len(created_time.name),
-            ),
-        ],
-        after=[],
-    )
-    response = client.post(
-        "/wikidata/events", data=event_input.model_dump_json(), headers=auth_headers
-    )
-    assert response.status_code == 200, response.text
+            tags=[
+                TagInput(
+                    id=created_person.id,
+                    name=created_person.name,
+                    start_char=summary_text.find(created_person.name),
+                    stop_char=summary_text.find(created_person.name)
+                    + len(created_person.name),
+                ),
+                TagInput(
+                    id=created_place.id,
+                    name=created_place.name,
+                    start_char=summary_text.find(created_place.name),
+                    stop_char=summary_text.find(created_place.name)
+                    + len(created_place.name),
+                ),
+                TagInput(
+                    id=created_time.id,
+                    name=created_time.name,
+                    start_char=summary_text.find(created_time.name),
+                    stop_char=summary_text.find(created_time.name)
+                    + len(created_time.name),
+                ),
+            ],
+            after=[],
+        )
+        return event_input
+
+    def test_create_event(self, client: TestClient, auth_headers: dict):
+        event_input = self._event(client, auth_headers)
+        response = client.post(
+            "/wikidata/events", data=event_input.model_dump_json(), headers=auth_headers
+        )
+        assert response.status_code == 200, response.text
+
+    def test_without_after(self, client: TestClient, auth_headers: dict) -> None:
+        FIRST_SUMMARY = "summary one"
+        SECOND_SUMMARY = "summary two"
+        event_input = self._event(client, auth_headers)
+        event_input.summary = FIRST_SUMMARY
+        response = client.post(
+            "/wikidata/events", data=event_input.model_dump_json(), headers=auth_headers
+        )
+        assert response.status_code == 200, response.text
+
+        event_input.summary = SECOND_SUMMARY
+        event_input.after = []
+        response = client.post(
+            "/wikidata/events", data=event_input.model_dump_json(), headers=auth_headers
+        )
+        assert response.status_code == 200, response.text
+
+        history_json = client.get("/api/history")
+        assert history_json.status_code == 200, history_json.text
+        story = Story.model_validate(history_json.json())
+
+        # expect the second event to be inserted first
+        assert story.events[0].text == SECOND_SUMMARY
+        assert story.events[1].text == FIRST_SUMMARY
+
+    def test_with_single_after_id(self, client: TestClient, auth_headers: dict) -> None:
+        FIRST_SUMMARY = "summary one"
+        SECOND_SUMMARY = "summary two"
+        event_input = self._event(client, auth_headers)
+        event_input.summary = FIRST_SUMMARY
+        response = client.post(
+            "/wikidata/events", data=event_input.model_dump_json(), headers=auth_headers
+        )
+        assert response.status_code == 200, response.text
+
+        # add the ID of our first created event to the after field
+        after = [UUID(response.json()["id"])]
+        event_input.summary = SECOND_SUMMARY
+        event_input.after = after
+        response = client.post(
+            "/wikidata/events", data=event_input.model_dump_json(), headers=auth_headers
+        )
+        assert response.status_code == 200, response.text
+
+        history_json = client.get("/api/history")
+        assert history_json.status_code == 200, history_json.text
+        story = Story.model_validate(history_json.json())
+
+        assert story.events[0].text == FIRST_SUMMARY
+        assert story.events[1].text == SECOND_SUMMARY
+
+    def test_with_multiple_after_ids(
+        self, client: TestClient, auth_headers: dict
+    ) -> None:
+        summary_base = "seed summary"
+        sentinal_summary = "our totally original summary text to mark the event we're inserting _after_ everything else."
+        event_input = self._event(client, auth_headers)
+        after = []
+        for i in range(3):
+            event_input.summary = f"{summary_base} {i}"
+            response = client.post(
+                "/wikidata/events",
+                data=event_input.model_dump_json(),
+                headers=auth_headers,
+            )
+            assert response.status_code == 200, response.text
+            after.append(UUID(response.json()["id"]))
+
+        event_input.summary = sentinal_summary
+        event_input.after = after
+        response = client.post(
+            "/wikidata/events", data=event_input.model_dump_json(), headers=auth_headers
+        )
+        assert response.status_code == 200, response.text
+
+        history_json = client.get("/api/history")
+        assert history_json.status_code == 200, history_json.text
+        story = Story.model_validate(history_json.json())
+
+        for i in range(3):
+            assert summary_base in story.events[i].text
+        assert story.events[-1].text == sentinal_summary
 
 
 @pytest.fixture

--- a/server/tests/test_api/test_rest.py
+++ b/server/tests/test_api/test_rest.py
@@ -169,7 +169,9 @@ def _generate_fake_event(
         wikidata_item_url=person.wikidata_url,
     )
 
-    return WikiDataEventInput(summary=summary_text, tags=tags, citation=citation)
+    return WikiDataEventInput(
+        summary=summary_text, tags=tags, citation=citation, after=[]
+    )
 
 
 def create_event(
@@ -378,6 +380,7 @@ def test_create_event(client: TestClient, auth_headers: dict):
                 stop_char=summary_text.find(created_time.name) + len(created_time.name),
             ),
         ],
+        after=[],
     )
     response = client.post(
         "/wikidata/events", data=event_input.model_dump_json(), headers=auth_headers

--- a/server/tests/test_apps/history/test_database.py
+++ b/server/tests/test_apps/history/test_database.py
@@ -180,6 +180,7 @@ def test_create_tag_instance(history_db):
             session=session,
             tag_instance_time=datetime.now(timezone.utc),
             time_precision=9,
+            after=[],
         )
         session.commit()
 

--- a/server/the_history_atlas/api/handlers/tags.py
+++ b/server/the_history_atlas/api/handlers/tags.py
@@ -5,7 +5,6 @@ from the_history_atlas.api.types.tags import (
     WikiDataPlaceOutput,
     WikiDataTimeInput,
     WikiDataTimeOutput,
-    WikiDataTagsInput,
     WikiDataTagsOutput,
     WikiDataTagPointer,
     WikiDataEventInput,
@@ -55,5 +54,6 @@ def create_event_handler(
         text=event.summary,
         tags=event.tags,
         citation=event.citation,
+        after=event.after,
     )
     return WikiDataEventOutput(id=id)

--- a/server/the_history_atlas/api/types/tags.py
+++ b/server/the_history_atlas/api/types/tags.py
@@ -74,6 +74,7 @@ class WikiDataEventInput(BaseModel):
     summary: str
     tags: list[TagInput]
     citation: WikiDataCitationInput
+    after: list[UUID]
 
 
 class WikiDataEventOutput(BaseModel):

--- a/server/the_history_atlas/apps/history/history_app.py
+++ b/server/the_history_atlas/apps/history/history_app.py
@@ -178,6 +178,7 @@ class HistoryApp:
         text: str,
         tags: list[TagInstance],
         citation: CitationInput,
+        after: list[UUID],
     ):
         source = self._repository.get_source_by_title(title="Wikidata")
         if source:
@@ -231,6 +232,7 @@ class HistoryApp:
                     tag_id=tag.id,
                     tag_instance_time=tag_instance_time,
                     time_precision=precision,
+                    after=after,
                     session=session,
                 )
             session.commit()

--- a/server/the_history_atlas/apps/history/repository.py
+++ b/server/the_history_atlas/apps/history/repository.py
@@ -806,15 +806,18 @@ class Repository:
         ).all()
         story_order_map = {row.summary_id: row.story_order for row in story_order_rows}
 
-        story_order = [
-            StoryOrder(
-                summary_id=summary_id,
-                story_order=story_order_map[summary_id],
-                datetime=row.datetime,
-                precision=row.precision,
-            )
-            for summary_id, row in summary_map.items()
-        ]
+        story_order = sorted(
+            [
+                StoryOrder(
+                    summary_id=summary_id,
+                    story_order=story_order_map[summary_id],
+                    datetime=row.datetime,
+                    precision=row.precision,
+                )
+                for summary_id, row in summary_map.items()
+            ],
+            key=lambda row: row.story_order,
+        )
         if not story_order:
             return 0
         for row in story_order:

--- a/server/the_history_atlas/apps/history/repository.py
+++ b/server/the_history_atlas/apps/history/repository.py
@@ -720,6 +720,7 @@ class Repository:
         tag_id: UUID,
         tag_instance_time: str,
         time_precision: TimePrecision,
+        after: list[UUID],
         session: Session,
     ) -> TagInstanceModel:
         story_order = self.get_story_order(
@@ -727,6 +728,7 @@ class Repository:
             tag_id=tag_id,
             tag_instance_time=tag_instance_time,
             time_precision=time_precision,
+            after=after,
         )
         self.update_story_orders(
             session=session,
@@ -757,6 +759,7 @@ class Repository:
         tag_id: UUID,
         tag_instance_time: str,
         time_precision: TimePrecision,
+        after: list[UUID],
     ) -> int:
         """Given a tag, find the order belonging to a given time."""
         summary_rows = session.execute(
@@ -818,6 +821,10 @@ class Repository:
             if row.datetime < tag_instance_time:
                 continue
             elif row.datetime == tag_instance_time and row.precision < time_precision:
+                continue
+            elif row.summary_id in after:
+                # make a best effort to put this summary after the given IDs,
+                # but only if the time matches
                 continue
             else:
                 return row.story_order

--- a/wiki_link/tests/test_database.py
+++ b/wiki_link/tests/test_database.py
@@ -242,7 +242,18 @@ def test_upsert_created_event_new_row(config):
         assert row.wiki_id == wiki_id
         assert row.factory_label == factory_label
         assert row.factory_version == factory_version
-        assert row.errors == {'Q12345': {'error1': 'test error'}}
+        assert row.errors == errors
+
+        # Clean up - delete created_events first due to foreign key constraint
+        session.execute(
+            text(
+                """
+                delete from created_events
+                where factory_result_id = :factory_result_id
+                """
+            ),
+            {"factory_result_id": row.id},
+        )
         session.delete(row)
         session.commit()
 
@@ -282,6 +293,17 @@ def test_upsert_created_event_update_row(config):
         assert row.factory_label == factory_label
         assert row.factory_version == updated_version
         assert row.errors == updated_errors
+
+        # Clean up - delete created_events first due to foreign key constraint
+        session.execute(
+            text(
+                """
+                delete from created_events
+                where factory_result_id = :factory_result_id
+                """
+            ),
+            {"factory_result_id": row.id},
+        )
         session.delete(row)
         session.commit()
 
@@ -309,6 +331,17 @@ def test_upsert_created_event_no_errors(config):
         assert row.factory_label == factory_label
         assert row.factory_version == factory_version
         assert row.errors == {}
+
+        # Clean up - delete created_events first due to foreign key constraint
+        session.execute(
+            text(
+                """
+                delete from created_events
+                where factory_result_id = :factory_result_id
+                """
+            ),
+            {"factory_result_id": row.id},
+        )
         session.delete(row)
         session.commit()
 
@@ -343,6 +376,16 @@ def test_event_exists_matching_row(config):
     with Session(db._engine, future=True) as session:
         row = (
             session.query(FactoryResult).filter(FactoryResult.wiki_id == wiki_id).one()
+        )
+        # Clean up - delete created_events first due to foreign key constraint
+        session.execute(
+            text(
+                """
+                delete from created_events
+                where factory_result_id = :factory_result_id
+                """
+            ),
+            {"factory_result_id": row.id},
         )
         session.delete(row)
         session.commit()
@@ -396,6 +439,16 @@ def test_event_exists_different_version(config):
         row = (
             session.query(FactoryResult).filter(FactoryResult.wiki_id == wiki_id).one()
         )
+        # Clean up - delete created_events first due to foreign key constraint
+        session.execute(
+            text(
+                """
+                delete from created_events
+                where factory_result_id = :factory_result_id
+                """
+            ),
+            {"factory_result_id": row.id},
+        )
         session.delete(row)
         session.commit()
 
@@ -429,6 +482,16 @@ def test_event_exists_different_factory(config):
     with Session(db._engine, future=True) as session:
         row = (
             session.query(FactoryResult).filter(FactoryResult.wiki_id == wiki_id).one()
+        )
+        # Clean up - delete created_events first due to foreign key constraint
+        session.execute(
+            text(
+                """
+                delete from created_events
+                where factory_result_id = :factory_result_id
+                """
+            ),
+            {"factory_result_id": row.id},
         )
         session.delete(row)
         session.commit()

--- a/wiki_link/tests/test_database.py
+++ b/wiki_link/tests/test_database.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 
 import pytest
 from wiki_service.database import Database, Item
-from wiki_service.schema import IDLookup, WikiQueue, Config, CreatedEvents
+from wiki_service.schema import IDLookup, WikiQueue, Config, FactoryResult
 from wiki_service.types import EntityType, WikiDataItem
 from sqlalchemy import create_engine, text
 
@@ -237,7 +237,7 @@ def test_upsert_created_event_new_row(config):
     # Verify row was created correctly
     with Session(db._engine, future=True) as session:
         row = (
-            session.query(CreatedEvents).filter(CreatedEvents.wiki_id == wiki_id).one()
+            session.query(FactoryResult).filter(FactoryResult.wiki_id == wiki_id).one()
         )
         assert row.wiki_id == wiki_id
         assert row.factory_label == factory_label
@@ -276,7 +276,7 @@ def test_upsert_created_event_update_row(config):
     # Verify row was updated correctly
     with Session(db._engine, future=True) as session:
         row = (
-            session.query(CreatedEvents).filter(CreatedEvents.wiki_id == wiki_id).one()
+            session.query(FactoryResult).filter(FactoryResult.wiki_id == wiki_id).one()
         )
         assert row.wiki_id == wiki_id
         assert row.factory_label == factory_label
@@ -303,7 +303,7 @@ def test_upsert_created_event_no_errors(config):
     # Verify row was created correctly
     with Session(db._engine, future=True) as session:
         row = (
-            session.query(CreatedEvents).filter(CreatedEvents.wiki_id == wiki_id).one()
+            session.query(FactoryResult).filter(FactoryResult.wiki_id == wiki_id).one()
         )
         assert row.wiki_id == wiki_id
         assert row.factory_label == factory_label
@@ -342,7 +342,7 @@ def test_event_exists_matching_row(config):
     # Clean up
     with Session(db._engine, future=True) as session:
         row = (
-            session.query(CreatedEvents).filter(CreatedEvents.wiki_id == wiki_id).one()
+            session.query(FactoryResult).filter(FactoryResult.wiki_id == wiki_id).one()
         )
         session.delete(row)
         session.commit()
@@ -394,7 +394,7 @@ def test_event_exists_different_version(config):
     # Clean up
     with Session(db._engine, future=True) as session:
         row = (
-            session.query(CreatedEvents).filter(CreatedEvents.wiki_id == wiki_id).one()
+            session.query(FactoryResult).filter(FactoryResult.wiki_id == wiki_id).one()
         )
         session.delete(row)
         session.commit()
@@ -428,7 +428,7 @@ def test_event_exists_different_factory(config):
     # Clean up
     with Session(db._engine, future=True) as session:
         row = (
-            session.query(CreatedEvents).filter(CreatedEvents.wiki_id == wiki_id).one()
+            session.query(FactoryResult).filter(FactoryResult.wiki_id == wiki_id).one()
         )
         session.delete(row)
         session.commit()

--- a/wiki_link/tests/test_database.py
+++ b/wiki_link/tests/test_database.py
@@ -242,7 +242,7 @@ def test_upsert_created_event_new_row(config):
         assert row.wiki_id == wiki_id
         assert row.factory_label == factory_label
         assert row.factory_version == factory_version
-        assert row.errors == errors
+        assert row.errors == {'Q12345': {'error1': 'test error'}}
         session.delete(row)
         session.commit()
 

--- a/wiki_link/tests/test_database.py
+++ b/wiki_link/tests/test_database.py
@@ -501,7 +501,7 @@ def test_get_server_id_by_event_label_no_matches(config):
     """Test when no matches are found"""
     db = Database(config=config)
     result = db.get_server_id_by_event_label(
-        event_label=["nonexistent_label"],
+        event_labels=["nonexistent_label"],
         primary_entity_id="Q12345",
     )
     assert result == []
@@ -526,7 +526,7 @@ def test_get_server_id_by_event_label_with_matches(config):
 
     # Test with matching primary entity only
     result = db.get_server_id_by_event_label(
-        event_label=[factory_label],
+        event_labels=[factory_label],
         primary_entity_id=wiki_id,
     )
     assert result == [server_id]
@@ -543,7 +543,7 @@ def test_get_server_id_by_event_label_with_matches(config):
 
     # Test with both primary and secondary entity
     result = db.get_server_id_by_event_label(
-        event_label=[factory_label],
+        event_labels=[factory_label],
         primary_entity_id=wiki_id,
         secondary_entity_id=secondary_id,
     )
@@ -551,7 +551,7 @@ def test_get_server_id_by_event_label_with_matches(config):
 
     # Test with multiple event labels
     result = db.get_server_id_by_event_label(
-        event_label=[factory_label, "another_label"],
+        event_labels=[factory_label, "another_label"],
         primary_entity_id=wiki_id,
     )
     assert sorted(result) == sorted([server_id, server_id2])
@@ -585,7 +585,7 @@ def test_get_server_id_by_event_label_null_server_ids(config):
     )
 
     result = db.get_server_id_by_event_label(
-        event_label=[factory_label],
+        event_labels=[factory_label],
         primary_entity_id=wiki_id,
     )
     assert result == []

--- a/wiki_link/tests/test_rest_client.py
+++ b/wiki_link/tests/test_rest_client.py
@@ -184,7 +184,9 @@ def test_create_event_with_non_ascii_text(mock_session, config):
         "source": "Historia de América",
     }
 
-    result = client.create_event(summary=summary, tags=tags, citation=citation)
+    result = client.create_event(
+        summary=summary, tags=tags, citation=citation, after=[]
+    )
 
     # Verify the request was made with correct data
     mock_session.post.assert_called_once()

--- a/wiki_link/tests/test_wiki_service.py
+++ b/wiki_link/tests/test_wiki_service.py
@@ -1074,6 +1074,8 @@ class TestBuildEvents:
         time_definition.precision = 11
         time_tag.time_definition = time_definition
         mock_event.time_tag = time_tag
+        mock_event.entity_id = "Q1"
+        mock_event.secondary_entity_id = "Q2"
 
         mock_event_factory.create_wiki_event.return_value = [mock_event]
 
@@ -1108,7 +1110,9 @@ class TestBuildEvents:
             mock_rest_client.create_place.return_value = {"id": "place-uuid"}
 
             # Mock successful event creation
-            mock_rest_client.create_event.return_value = {"id": "event-uuid"}
+            mock_rest_client.create_event.return_value = {
+                "id": "4bf4d9ed-e912-4f28-b366-81c4e41a500b"
+            }
 
             # Act
             wiki_service.build_events(item=item_mock)

--- a/wiki_link/wiki_service/database.py
+++ b/wiki_link/wiki_service/database.py
@@ -373,7 +373,7 @@ class Database:
 
     def get_server_id_by_event_label(
         self,
-        event_label: list[str],
+        event_labels: list[str],
         primary_entity_id: str,
         secondary_entity_id: str | None = None,
     ) -> list[UUID]:
@@ -381,7 +381,7 @@ class Database:
         Query server_ids from created_events based on event labels and entity IDs.
 
         Args:
-            event_label: List of factory labels to filter by
+            event_labels: List of factory labels to filter by
             primary_entity_id: Primary entity ID to filter by
             secondary_entity_id: Optional secondary entity ID to filter by
 
@@ -407,7 +407,7 @@ class Database:
             result = session.execute(
                 query,
                 {
-                    "event_label": event_label,
+                    "event_label": event_labels,
                     "primary_entity_id": primary_entity_id,
                     "secondary_entity_id": secondary_entity_id,
                 },

--- a/wiki_link/wiki_service/database.py
+++ b/wiki_link/wiki_service/database.py
@@ -14,7 +14,7 @@ from wiki_service.config import WikiServiceConfig
 from wiki_service.schema import Base, WikiQueue
 from wiki_service.schema import IDLookup
 from wiki_service.schema import Config as ConfigModel
-from wiki_service.schema import CreatedEvents
+from wiki_service.schema import FactoryResult
 from wiki_service.types import EntityType, WikiDataItem
 
 log = logging.getLogger(__name__)
@@ -258,7 +258,7 @@ class Database:
             row = session.execute(
                 text(
                     """
-                        select factory_version, errors from created_events
+                        select factory_version, errors from factory_results
                         where wiki_id = :wiki_id
                         and factory_label = :factory_label
                     """
@@ -266,7 +266,7 @@ class Database:
                 {"wiki_id": wiki_id, "factory_label": factory_label},
             ).one_or_none()
             if row is None:
-                row = CreatedEvents(
+                row = FactoryResult(
                     wiki_id=wiki_id,
                     factory_label=factory_label,
                     factory_version=factory_version,
@@ -277,7 +277,7 @@ class Database:
                 session.execute(
                     text(
                         """
-                        update created_events
+                        update factory_results
                         set factory_version = :factory_version,
                             errors = :errors,
                             updated_at = :updated_at
@@ -314,7 +314,7 @@ class Database:
             row = session.execute(
                 text(
                     """
-                        select 1 from created_events
+                        select 1 from factory_results
                         where wiki_id = :wiki_id
                         and factory_label = :factory_label
                         and factory_version = :factory_version;

--- a/wiki_link/wiki_service/database.py
+++ b/wiki_link/wiki_service/database.py
@@ -3,6 +3,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Optional, List
+from uuid import UUID, uuid4
 
 from sqlalchemy import create_engine
 from sqlalchemy import text
@@ -11,7 +12,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
 
 from wiki_service.config import WikiServiceConfig
-from wiki_service.schema import Base, WikiQueue
+from wiki_service.schema import Base, WikiQueue, CreatedEvent
 from wiki_service.schema import IDLookup
 from wiki_service.schema import Config as ConfigModel
 from wiki_service.schema import FactoryResult
@@ -242,6 +243,8 @@ class Database:
         factory_label: str,
         factory_version: int,
         errors: Optional[dict] = None,
+        server_id: Optional[UUID] = None,
+        secondary_wiki_id: str | None = None,
     ) -> None:
         """
         Create or update a CreatedEvents row.
@@ -253,27 +256,44 @@ class Database:
             factory_label: The label of the factory that created the event
             factory_version: The version of the factory
             errors: Optional dictionary of errors encountered during creation
+            server_id: Optional UUID of the server that created the event
+            secondary_wiki_id: Optional secondary wiki ID for events involving two entities
         """
         with Session(self._engine, future=True) as session:
-            row = session.execute(
+            # First find or create the factory result
+            factory_result = session.execute(
                 text(
                     """
-                        select factory_version, errors from factory_results
-                        where wiki_id = :wiki_id
-                        and factory_label = :factory_label
+                    select id, factory_version, errors from factory_results
+                    where wiki_id = :wiki_id
+                    and factory_label = :factory_label
                     """
                 ),
                 {"wiki_id": wiki_id, "factory_label": factory_label},
             ).one_or_none()
-            if row is None:
-                row = FactoryResult(
-                    wiki_id=wiki_id,
-                    factory_label=factory_label,
-                    factory_version=factory_version,
-                    errors=errors or {},
+
+            if factory_result is None:
+                # Create new factory result
+                factory_result_id = uuid4()
+                session.execute(
+                    text(
+                        """
+                        insert into factory_results (id, wiki_id, factory_label, factory_version, errors, updated_at)
+                        values (:id, :wiki_id, :factory_label, :factory_version, :errors, :updated_at)
+                        """
+                    ),
+                    {
+                        "id": factory_result_id,
+                        "wiki_id": wiki_id,
+                        "factory_label": factory_label,
+                        "factory_version": factory_version,
+                        "errors": json.dumps(errors if errors is not None else {}),
+                        "updated_at": datetime.now(timezone.utc),
+                    },
                 )
-                session.add(row)
             else:
+                factory_result_id = factory_result[0]
+                # Update existing factory result
                 session.execute(
                     text(
                         """
@@ -281,18 +301,33 @@ class Database:
                         set factory_version = :factory_version,
                             errors = :errors,
                             updated_at = :updated_at
-                        where wiki_id = :wiki_id
-                        and factory_label = :factory_label;
+                        where id = :id
                         """
                     ),
                     {
-                        "wiki_id": wiki_id,
-                        "factory_label": factory_label,
+                        "id": factory_result_id,
                         "factory_version": factory_version,
-                        "errors": json.dumps(errors) if errors else json.dumps({}),
+                        "errors": json.dumps(errors if errors is not None else {}),
                         "updated_at": datetime.now(timezone.utc),
                     },
                 )
+
+            # Now create the created event
+            session.execute(
+                text(
+                    """
+                    insert into created_events (id, factory_result_id, primary_entity_id, secondary_entity_id, server_id)
+                    values (:id, :factory_result_id, :primary_entity_id, :secondary_entity_id, :server_id)
+                    """
+                ),
+                {
+                    "id": uuid4(),
+                    "factory_result_id": factory_result_id,
+                    "primary_entity_id": wiki_id,
+                    "secondary_entity_id": secondary_wiki_id,
+                    "server_id": server_id,
+                },
+            )
 
             session.commit()
 
@@ -311,13 +346,13 @@ class Database:
             bool: True if a matching row exists, False otherwise
         """
         with Session(self._engine, future=True) as session:
-            row = session.execute(
+            result = session.execute(
                 text(
                     """
-                        select 1 from factory_results
-                        where wiki_id = :wiki_id
-                        and factory_label = :factory_label
-                        and factory_version = :factory_version;
+                    select 1 from factory_results
+                    where wiki_id = :wiki_id
+                    and factory_label = :factory_label
+                    and factory_version = :factory_version;
                     """
                 ),
                 {
@@ -326,7 +361,7 @@ class Database:
                     "factory_version": factory_version,
                 },
             ).one_or_none()
-            return row is not None
+            return result is not None
 
     @classmethod
     def factory(cls) -> "Database":

--- a/wiki_link/wiki_service/event_factories/book_was_published.py
+++ b/wiki_link/wiki_service/event_factories/book_was_published.py
@@ -122,14 +122,18 @@ class BookWasPublished(EventFactory):
             time_definition=time_definition,
         )
 
-        return [
+        events = [
             WikiEvent(
                 summary=summary,
                 people_tags=people_tags,
                 place_tag=place_tag,
                 time_tag=time_tag,
+                entity_id=self._entity_id,
+                secondary_entity_id=None,
             )
         ]
+
+        return events
 
     def _country_of_origin_id(self) -> str:
         return self._entity.claims[COUNTRY_OF_ORIGIN][0]["mainsnak"]["datavalue"][

--- a/wiki_link/wiki_service/event_factories/event_factory.py
+++ b/wiki_link/wiki_service/event_factories/event_factory.py
@@ -35,6 +35,12 @@ class EventFactory(ABC):
         """Get the label of the event factory."""
         pass
 
+    @property
+    def after_labels(self) -> set[str]:
+        """Represent logical relationships between types of events, in the
+        case that they share a date."""
+        return set()
+
     @abstractmethod
     def entity_has_event(self) -> bool:
         """Check if the entity has this type of event."""

--- a/wiki_link/wiki_service/event_factories/event_factory.py
+++ b/wiki_link/wiki_service/event_factories/event_factory.py
@@ -36,10 +36,10 @@ class EventFactory(ABC):
         pass
 
     @property
-    def after_labels(self) -> set[str]:
+    def after_labels(self) -> list[str]:
         """Represent logical relationships between types of events, in the
         case that they share a date."""
-        return set()
+        return []
 
     @abstractmethod
     def entity_has_event(self) -> bool:

--- a/wiki_link/wiki_service/event_factories/event_factory.py
+++ b/wiki_link/wiki_service/event_factories/event_factory.py
@@ -21,6 +21,7 @@ class EventFactory(ABC):
         self._entity = entity
         self._query = query
         self._entity_type = entity_type
+        self._entity_id = entity.id  # Store the entity ID for use in WikiEvent creation
 
     @property
     @abstractmethod

--- a/wiki_link/wiki_service/event_factories/oration_delivered.py
+++ b/wiki_link/wiki_service/event_factories/oration_delivered.py
@@ -202,6 +202,8 @@ class OrationDelivered(EventFactory):
                 people_tags=people_tags,
                 place_tag=place_tag,
                 time_tag=time_tag,
+                entity_id=person_id,
+                secondary_entity_id=self._entity_id,
             )
         )
 

--- a/wiki_link/wiki_service/event_factories/person_died.py
+++ b/wiki_link/wiki_service/event_factories/person_died.py
@@ -89,6 +89,8 @@ class PersonDied(EventFactory):
                 people_tags=people_tags,
                 place_tag=place_tag,
                 time_tag=time_tag,
+                entity_id=self._entity_id,
+                secondary_entity_id=None,
             )
         ]
 

--- a/wiki_link/wiki_service/event_factories/person_education_began.py
+++ b/wiki_link/wiki_service/event_factories/person_education_began.py
@@ -148,6 +148,8 @@ class PersonEducationBegan(EventFactory):
                     people_tags=people_tags,
                     place_tag=place_tag,
                     time_tag=time_tag,
+                    entity_id=self._entity_id,
+                    secondary_entity_id=institution_id,
                 )
             )
 

--- a/wiki_link/wiki_service/event_factories/person_education_ended.py
+++ b/wiki_link/wiki_service/event_factories/person_education_ended.py
@@ -207,6 +207,8 @@ class PersonEducationEnded(EventFactory):
                     people_tags=people_tags,
                     place_tag=place_tag,
                     time_tag=time_tag,
+                    entity_id=self._entity_id,
+                    secondary_entity_id=institution_id,
                 )
             )
 

--- a/wiki_link/wiki_service/event_factories/person_education_ended.py
+++ b/wiki_link/wiki_service/event_factories/person_education_ended.py
@@ -51,6 +51,10 @@ class PersonEducationEnded(EventFactory):
     def label(self):
         return "Person education ended"
 
+    @property
+    def after_labels(self) -> set[str]:
+        return {"Person education began"}
+
     def entity_has_event(self) -> bool:
         if self._entity_type != "PERSON":
             return False

--- a/wiki_link/wiki_service/event_factories/person_education_ended.py
+++ b/wiki_link/wiki_service/event_factories/person_education_ended.py
@@ -52,8 +52,8 @@ class PersonEducationEnded(EventFactory):
         return "Person education ended"
 
     @property
-    def after_labels(self) -> set[str]:
-        return {"Person education began"}
+    def after_labels(self) -> list[str]:
+        return ["Person education began"]
 
     def entity_has_event(self) -> bool:
         if self._entity_type != "PERSON":

--- a/wiki_link/wiki_service/event_factories/person_left_position.py
+++ b/wiki_link/wiki_service/event_factories/person_left_position.py
@@ -43,6 +43,10 @@ class PersonLeftPosition(EventFactory):
     def label(self):
         return "Person left position"
 
+    @property
+    def after_labels(self) -> set[str]:
+        return {"Person took position"}
+
     def entity_has_event(self) -> bool:
         if self._entity_type != "PERSON":
             return False

--- a/wiki_link/wiki_service/event_factories/person_left_position.py
+++ b/wiki_link/wiki_service/event_factories/person_left_position.py
@@ -44,8 +44,8 @@ class PersonLeftPosition(EventFactory):
         return "Person left position"
 
     @property
-    def after_labels(self) -> set[str]:
-        return {"Person took position"}
+    def after_labels(self) -> list[str]:
+        return ["Person took position"]
 
     def entity_has_event(self) -> bool:
         if self._entity_type != "PERSON":

--- a/wiki_link/wiki_service/event_factories/person_left_position.py
+++ b/wiki_link/wiki_service/event_factories/person_left_position.py
@@ -225,6 +225,8 @@ class PersonLeftPosition(EventFactory):
                     people_tags=people_tags,
                     place_tag=place_tag,
                     time_tag=time_tag,
+                    entity_id=self._entity_id,
+                    secondary_entity_id=position_id,
                 )
             )
 

--- a/wiki_link/wiki_service/event_factories/person_moved_away_from.py
+++ b/wiki_link/wiki_service/event_factories/person_moved_away_from.py
@@ -126,6 +126,8 @@ class PersonMovedAwayFrom(EventFactory):
                     people_tags=people_tags,
                     place_tag=place_tag,
                     time_tag=time_tag,
+                    entity_id=self._entity_id,
+                    secondary_entity_id=residence_id,
                 )
             )
 

--- a/wiki_link/wiki_service/event_factories/person_moved_away_from.py
+++ b/wiki_link/wiki_service/event_factories/person_moved_away_from.py
@@ -33,8 +33,8 @@ class PersonMovedAwayFrom(EventFactory):
         return "Person moved away from"
 
     @property
-    def after_labels(self):
-        return {"Person moved to"}
+    def after_labels(self) -> list[str]:
+        return ["Person moved to"]
 
     def entity_has_event(self) -> bool:
         if self._entity_type != "PERSON":

--- a/wiki_link/wiki_service/event_factories/person_moved_away_from.py
+++ b/wiki_link/wiki_service/event_factories/person_moved_away_from.py
@@ -32,6 +32,10 @@ class PersonMovedAwayFrom(EventFactory):
     def label(self):
         return "Person moved away from"
 
+    @property
+    def after_labels(self):
+        return {"Person moved to"}
+
     def entity_has_event(self) -> bool:
         if self._entity_type != "PERSON":
             return False

--- a/wiki_link/wiki_service/event_factories/person_moved_to.py
+++ b/wiki_link/wiki_service/event_factories/person_moved_to.py
@@ -126,6 +126,8 @@ class PersonMovedTo(EventFactory):
                     people_tags=people_tags,
                     place_tag=place_tag,
                     time_tag=time_tag,
+                    entity_id=self._entity_id,
+                    secondary_entity_id=residence_id,
                 )
             )
 

--- a/wiki_link/wiki_service/event_factories/person_nominated_for.py
+++ b/wiki_link/wiki_service/event_factories/person_nominated_for.py
@@ -221,6 +221,8 @@ class PersonNominatedFor(EventFactory):
                     people_tags=people_tags,
                     place_tag=place_tag,
                     time_tag=time_tag,
+                    entity_id=self._entity_id,
+                    secondary_entity_id=award_id,
                 )
             )
 

--- a/wiki_link/wiki_service/event_factories/person_participated_in.py
+++ b/wiki_link/wiki_service/event_factories/person_participated_in.py
@@ -165,6 +165,8 @@ class PersonParticipatedIn(EventFactory):
                     people_tags=people_tags,
                     place_tag=place_tag,
                     time_tag=time_tag,
+                    entity_id=self._entity_id,
+                    secondary_entity_id=event_id,
                 )
             )
 

--- a/wiki_link/wiki_service/event_factories/person_received_academic_degree.py
+++ b/wiki_link/wiki_service/event_factories/person_received_academic_degree.py
@@ -230,6 +230,8 @@ class PersonReceivedAcademicDegree(EventFactory):
                         people_tags=people_tags,
                         place_tag=place_tag,
                         time_tag=time_tag,
+                        entity_id=self._entity_id,
+                        secondary_entity_id=degree_id,
                     )
                 )
 

--- a/wiki_link/wiki_service/event_factories/person_received_award.py
+++ b/wiki_link/wiki_service/event_factories/person_received_award.py
@@ -47,6 +47,10 @@ class PersonReceivedAward(EventFactory):
     def label(self):
         return "Person received award"
 
+    @property
+    def after_labels(self):
+        return {"Person nominated for"}
+
     def entity_has_event(self) -> bool:
         if self._entity_type != "PERSON":
             return False

--- a/wiki_link/wiki_service/event_factories/person_received_award.py
+++ b/wiki_link/wiki_service/event_factories/person_received_award.py
@@ -48,8 +48,8 @@ class PersonReceivedAward(EventFactory):
         return "Person received award"
 
     @property
-    def after_labels(self):
-        return {"Person nominated for"}
+    def after_labels(self) -> list[str]:
+        return ["Person nominated for"]
 
     def entity_has_event(self) -> bool:
         if self._entity_type != "PERSON":

--- a/wiki_link/wiki_service/event_factories/person_received_award.py
+++ b/wiki_link/wiki_service/event_factories/person_received_award.py
@@ -168,7 +168,7 @@ class PersonReceivedAward(EventFactory):
             except Exception:  # todo: narrow exception
                 time_definition = self._query.get_time_definition_from_claim(
                     claim=award_claim,
-                    time_props=[POINT_IN_TIME, START_TIME],
+                    time_props=[POINT_IN_TIME],
                 )
             if time_definition is None:
                 continue

--- a/wiki_link/wiki_service/event_factories/person_received_award.py
+++ b/wiki_link/wiki_service/event_factories/person_received_award.py
@@ -232,6 +232,8 @@ class PersonReceivedAward(EventFactory):
                     people_tags=people_tags,
                     place_tag=place_tag,
                     time_tag=time_tag,
+                    entity_id=self._entity_id,
+                    secondary_entity_id=award_id,
                 )
             )
 

--- a/wiki_link/wiki_service/event_factories/person_started_working_for.py
+++ b/wiki_link/wiki_service/event_factories/person_started_working_for.py
@@ -139,6 +139,8 @@ class PersonStartedWorkingFor(EventFactory):
                     people_tags=people_tags,
                     place_tag=place_tag,
                     time_tag=time_tag,
+                    entity_id=self._entity_id,
+                    secondary_entity_id=employer_id,
                 )
             )
 

--- a/wiki_link/wiki_service/event_factories/person_stopped_working_for.py
+++ b/wiki_link/wiki_service/event_factories/person_stopped_working_for.py
@@ -36,6 +36,10 @@ class PersonStoppedWorkingFor(EventFactory):
     def label(self):
         return "Person stopped working for"
 
+    @property
+    def after_labels(self) -> set[str]:
+        return {"Person started working for"}
+
     def entity_has_event(self) -> bool:
         if self._entity_type != "PERSON":
             return False

--- a/wiki_link/wiki_service/event_factories/person_stopped_working_for.py
+++ b/wiki_link/wiki_service/event_factories/person_stopped_working_for.py
@@ -139,6 +139,8 @@ class PersonStoppedWorkingFor(EventFactory):
                     people_tags=people_tags,
                     place_tag=place_tag,
                     time_tag=time_tag,
+                    entity_id=self._entity_id,
+                    secondary_entity_id=employer_id,
                 )
             )
 

--- a/wiki_link/wiki_service/event_factories/person_stopped_working_for.py
+++ b/wiki_link/wiki_service/event_factories/person_stopped_working_for.py
@@ -37,8 +37,8 @@ class PersonStoppedWorkingFor(EventFactory):
         return "Person stopped working for"
 
     @property
-    def after_labels(self) -> set[str]:
-        return {"Person started working for"}
+    def after_labels(self) -> list[str]:
+        return ["Person started working for"]
 
     def entity_has_event(self) -> bool:
         if self._entity_type != "PERSON":

--- a/wiki_link/wiki_service/event_factories/person_took_position.py
+++ b/wiki_link/wiki_service/event_factories/person_took_position.py
@@ -222,6 +222,8 @@ class PersonTookPosition(EventFactory):
                     people_tags=people_tags,
                     place_tag=place_tag,
                     time_tag=time_tag,
+                    entity_id=self._entity_id,
+                    secondary_entity_id=position_id,
                 )
             )
 

--- a/wiki_link/wiki_service/event_factories/person_was_born.py
+++ b/wiki_link/wiki_service/event_factories/person_was_born.py
@@ -95,6 +95,8 @@ class PersonWasBorn(EventFactory):
                 people_tags=people_tags,
                 place_tag=place_tag,
                 time_tag=time_tag,
+                entity_id=self._entity_id,
+                secondary_entity_id=None,
             )
         ]
 

--- a/wiki_link/wiki_service/event_factories/work_of_art_created.py
+++ b/wiki_link/wiki_service/event_factories/work_of_art_created.py
@@ -140,14 +140,18 @@ class WorkOfArtCreated(EventFactory):
             time_definition=time_definition,
         )
 
-        return [
+        events = [
             WikiEvent(
                 summary=summary,
                 people_tags=people_tags,
                 place_tag=place_tag,
                 time_tag=time_tag,
+                entity_id=self._entity_id,
+                secondary_entity_id=None,
             )
         ]
+
+        return events
 
     def _creator_id(self) -> str:
         return self._entity.claims[CREATOR][0]["mainsnak"]["datavalue"]["value"]["id"]

--- a/wiki_link/wiki_service/rest_client.py
+++ b/wiki_link/wiki_service/rest_client.py
@@ -153,7 +153,12 @@ class RestClient:
         self, summary: str, tags: List[dict], citation: dict, after: list[UUID]
     ) -> dict:
         """Create a new event"""
-        data = {"summary": summary, "tags": tags, "citation": citation, "after": after}
+        data = {
+            "summary": summary,
+            "tags": tags,
+            "citation": citation,
+            "after": [str(id) for id in after],
+        }
         response = self._session.post(
             f"{self._base_url}/wikidata/events",
             data=json.dumps(data, ensure_ascii=False).encode("utf-8"),

--- a/wiki_link/wiki_service/rest_client.py
+++ b/wiki_link/wiki_service/rest_client.py
@@ -149,9 +149,11 @@ class RestClient:
         result = response.json()
         return UUID(result["id"]) if result["id"] else None
 
-    def create_event(self, summary: str, tags: List[dict], citation: dict) -> dict:
+    def create_event(
+        self, summary: str, tags: List[dict], citation: dict, after: list[UUID]
+    ) -> dict:
         """Create a new event"""
-        data = {"summary": summary, "tags": tags, "citation": citation}
+        data = {"summary": summary, "tags": tags, "citation": citation, "after": after}
         response = self._session.post(
             f"{self._base_url}/wikidata/events",
             data=json.dumps(data, ensure_ascii=False).encode("utf-8"),

--- a/wiki_link/wiki_service/schema.py
+++ b/wiki_link/wiki_service/schema.py
@@ -48,11 +48,13 @@ class FactoryResult(Base):
 
 class CreatedEvent(Base):
     __tablename__ = "created_events"
-    id = Column(UUID(as_uuid=True), primary_key=True)
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     factory_result_id = Column(
         UUID(as_uuid=True), ForeignKey("factory_results.id"), nullable=False
     )
-    entity_id = Column(VARCHAR, nullable=False)
+    primary_entity_id = Column(VARCHAR, nullable=False)
+    secondary_entity_id = Column(VARCHAR, nullable=True)
+    server_id = Column(UUID(as_uuid=True), nullable=True)
 
 
 class Config(Base):

--- a/wiki_link/wiki_service/schema.py
+++ b/wiki_link/wiki_service/schema.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Column
+from sqlalchemy import Column, ForeignKey
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.dialects.postgresql import VARCHAR, UUID, JSONB, INTEGER, TIMESTAMP
 
@@ -34,8 +34,8 @@ class WikiQueue(Base):
     time_added = Column(TIMESTAMP(timezone=True), nullable=False)
 
 
-class CreatedEvents(Base):
-    __tablename__ = "created_events"
+class FactoryResult(Base):
+    __tablename__ = "factory_results"
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     wiki_id = Column(VARCHAR, nullable=False)
     factory_label = Column(VARCHAR, nullable=False)
@@ -44,6 +44,15 @@ class CreatedEvents(Base):
     updated_at = Column(
         TIMESTAMP(timezone=True), nullable=False, default=datetime.now(timezone.utc)
     )
+
+
+class CreatedEvent(Base):
+    __tablename__ = "created_events"
+    id = Column(UUID(as_uuid=True), primary_key=True)
+    factory_result_id = Column(
+        UUID(as_uuid=True), ForeignKey("factory_results.id"), nullable=False
+    )
+    entity_id = Column(VARCHAR, nullable=False)
 
 
 class Config(Base):

--- a/wiki_link/wiki_service/types.py
+++ b/wiki_link/wiki_service/types.py
@@ -124,6 +124,8 @@ class WikiEvent(BaseModel):
     people_tags: List[PersonWikiTag]
     place_tag: PlaceWikiTag
     time_tag: TimeWikiTag
+    entity_id: str  # entity consumed by the event factory
+    secondary_entity_id: str | None = None  # property object, if used to create event
 
 
 class Query(Protocol):

--- a/wiki_link/wiki_service/wiki_service.py
+++ b/wiki_link/wiki_service/wiki_service.py
@@ -1,6 +1,7 @@
 from logging import getLogger
 from datetime import datetime, timezone
 from typing import Optional
+from uuid import UUID
 
 from wiki_service.config import WikiServiceConfig
 from wiki_service.database import Database, Item
@@ -464,12 +465,13 @@ class WikiService:
                 )
 
                 # Create the event
-                self._rest_client.create_event(
+                result = self._rest_client.create_event(
                     summary=event.summary,
                     tags=tags,
                     citation=citation,
                     after=[],
                 )
+                result_id = UUID(result["id"])
 
             # Record successful event creation after all events are created
             self._database.upsert_created_event(
@@ -477,6 +479,7 @@ class WikiService:
                 factory_label=event_factory.label,
                 factory_version=event_factory.version,
                 errors=None,
+                server_id=result_id,
             )
 
         except (RestClientError, Exception) as e:

--- a/wiki_link/wiki_service/wiki_service.py
+++ b/wiki_link/wiki_service/wiki_service.py
@@ -463,13 +463,18 @@ class WikiService:
                         "stop_char": event.time_tag.stop_char,
                     }
                 )
+                after = self._database.get_server_id_by_event_label(
+                    event_labels=event_factory.after_labels,
+                    primary_entity_id=event.entity_id,
+                    secondary_entity_id=event.secondary_entity_id,
+                )
 
                 # Create the event
                 result = self._rest_client.create_event(
                     summary=event.summary,
                     tags=tags,
                     citation=citation,
-                    after=[],
+                    after=after,
                 )
                 result_id = UUID(result["id"])
 

--- a/wiki_link/wiki_service/wiki_service.py
+++ b/wiki_link/wiki_service/wiki_service.py
@@ -468,6 +468,7 @@ class WikiService:
                     summary=event.summary,
                     tags=tags,
                     citation=citation,
+                    after=[],
                 )
 
             # Record successful event creation after all events are created

--- a/wiki_link/wiki_service/wiki_service.py
+++ b/wiki_link/wiki_service/wiki_service.py
@@ -473,14 +473,15 @@ class WikiService:
                 )
                 result_id = UUID(result["id"])
 
-            # Record successful event creation after all events are created
-            self._database.upsert_created_event(
-                wiki_id=wiki_id,
-                factory_label=event_factory.label,
-                factory_version=event_factory.version,
-                errors=None,
-                server_id=result_id,
-            )
+                # Record successful event creation for each event
+                self._database.upsert_created_event(
+                    wiki_id=wiki_id,
+                    factory_label=event_factory.label,
+                    factory_version=event_factory.version,
+                    errors=None,
+                    server_id=result_id,
+                    secondary_wiki_id=event.secondary_entity_id,
+                )
 
         except (RestClientError, Exception) as e:
             # Record error


### PR DESCRIPTION
The server eagerly inserts events, so if two events have equivalent times, the one created later will appear first. This PR adds functionality to allow the wiki link service to declare logical dependencies between events which share the same entity and entity property, so they appear in the correct order.

As an example, Barack Obama (Q76) has two occurrences where he started and left a job in the same year, and the PersonStoppedWorkingFor event was appearing before the PersonStartedWorkingFor event.